### PR TITLE
[GRO-18] Add upload bank statements path

### DIFF
--- a/src/app/api/bank-statement/route.ts
+++ b/src/app/api/bank-statement/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+export async function POST(request: NextRequest) {
+  try {
+    // Initialize Supabase client
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+    if (!supabaseUrl || !supabaseServiceKey) {
+      return NextResponse.json(
+        { error: 'Server configuration error' },
+        { status: 500 }
+      );
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+    // Get the form data
+    const formData = await request.formData();
+    const file = formData.get('file') as File;
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+    }
+
+    // Get application ID from headers
+    const applicationId = request.headers.get('X-Application-ID');
+
+    // Validate file type and size
+    const validTypes = [
+      'application/pdf',
+      'image/png',
+      'image/jpeg',
+      'image/jpg',
+      'application/msword',
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    ];
+    const maxSize = 10 * 1024 * 1024; // 10MB
+
+    if (!validTypes.includes(file.type)) {
+      return NextResponse.json(
+        {
+          error:
+            'Invalid file type. Please upload PDF, PNG, JPEG, or DOC files.',
+        },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > maxSize) {
+      return NextResponse.json(
+        { error: 'File too large. Maximum size is 10MB.' },
+        { status: 400 }
+      );
+    }
+
+    // Generate unique filename
+    const timestamp = Date.now();
+    const randomId = Math.random().toString(36).substring(7);
+    const fileName = applicationId
+      ? `${applicationId}/${timestamp}-${file.name}`
+      : `temp/${randomId}/${timestamp}-${file.name}`;
+
+    // Upload to Supabase Storage using standard upload
+    const { data: uploadData, error: uploadError } = await supabase.storage
+      .from('bank-statements')
+      .upload(fileName, file, {
+        contentType: file.type,
+        upsert: false,
+      });
+
+    if (uploadError) {
+      console.error('Upload error:', uploadError);
+      return NextResponse.json(
+        { error: 'Failed to upload file' },
+        { status: 500 }
+      );
+    }
+
+    // Save file metadata to database
+    const { data: dbData, error: dbError } = await supabase
+      .from('bank_statements')
+      .insert({
+        application_id: applicationId || null,
+        file_url: fileName, // Store the path
+        file_name: file.name,
+        file_size: file.size,
+        mime_type: file.type,
+      })
+      .select()
+      .single();
+
+    if (dbError) {
+      console.error('Database error:', dbError);
+
+      // Try to delete the uploaded file
+      await supabase.storage.from('bank-statements').remove([fileName]);
+
+      return NextResponse.json(
+        { error: 'Failed to save file metadata' },
+        { status: 500 }
+      );
+    }
+
+    // Generate a temporary signed URL for immediate display (expires in 1 hour)
+    const { data: signedUrlData, error: signedUrlError } =
+      await supabase.storage
+        .from('bank-statements')
+        .createSignedUrl(fileName, 3600); // 1 hour expiration
+
+    if (signedUrlError) {
+      console.error('Error creating signed URL:', signedUrlError);
+    }
+
+    return NextResponse.json({
+      id: dbData.id,
+      fileName: file.name,
+      fileUrl: signedUrlData?.signedUrl || fileName,
+      fileSize: file.size,
+      mimeType: file.type,
+    });
+  } catch (error) {
+    console.error('Server error:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/step/[id]/page.tsx
+++ b/src/app/step/[id]/page.tsx
@@ -1584,7 +1584,7 @@ function Step12Form({
                 <br />
               </h3>
               <p className="text-sm text-gray-600 mb-4">
-                Please upload 3 bank statements of the last 6 months to help us
+                Please upload your 3 most recent bank statements to help us
                 review your business.
               </p>
               <button className="w-full bg-gray-800 text-white py-3 px-4 rounded-lg font-semibold hover:bg-gray-700 transition-colors">
@@ -1698,8 +1698,8 @@ function Step12Form({
                   Upload Bank Statements Manually
                 </h3>
                 <p className="text-sm text-gray-600 mt-1">
-                  Please upload three bank statements that are no older than six
-                  months to help us understand your business.
+                  Please upload your three most recent bank statements to help
+                  us understand your business.
                 </p>
               </div>
             </div>

--- a/src/app/step/[id]/page.tsx
+++ b/src/app/step/[id]/page.tsx
@@ -1462,23 +1462,42 @@ function Step12Form({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Flinks Option */}
             <div
-              className="bg-purple-50 border-2 border-purple-200 rounded-lg p-6 hover:border-purple-400 transition-colors cursor-pointer"
+              className="bg-purple-50 border-2 border-purple-200 rounded-lg p-6 hover:border-purple-400 transition-colors cursor-pointer relative shadow-lg"
               onClick={() => handleMethodSelect('flinks')}
             >
-              <h3 className="text-lg font-semibold mb-2">
+              <div className="flex items-center gap-2 text-purple-600 mb-4">
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13 10V3L4 14h7v7l9-11h-7z"
+                  />
+                </svg>
+                <span className="text-sm font-medium">
+                  Faster option. Typically approved within 24 hours
+                </span>
+              </div>
+
+              <h3 className="text-xl font-bold mb-2">
                 Securely Connect your Bank Account
               </h3>
-              <p className="text-sm text-purple-600 mb-4">
+              <p className="text-sm text-gray-600 mb-4">
                 Keep uses Flinks to securely view your banking history — in
-                seconds with no paperwork required
+                seconds with no paperwork required.
               </p>
-              <button className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white py-3 px-4 rounded-lg font-medium hover:opacity-90 transition-opacity">
+              <button className="w-full bg-gradient-to-r from-purple-500 to-blue-500 text-white py-3 px-4 rounded-lg font-semibold hover:opacity-90 transition-opacity">
                 Connect your account
               </button>
               <div className="mt-4 space-y-2">
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-purple-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1490,9 +1509,9 @@ function Step12Form({
                   </svg>
                   Bank-level security protects your information.
                 </div>
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-purple-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1504,9 +1523,9 @@ function Step12Form({
                   </svg>
                   You control what we see - never your passwords.
                 </div>
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-purple-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1518,9 +1537,9 @@ function Step12Form({
                   </svg>
                   Faster approval with priority review.
                 </div>
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-purple-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1537,23 +1556,44 @@ function Step12Form({
 
             {/* Manual Upload Option */}
             <div
-              className="bg-white border-2 border-gray-200 rounded-lg p-6 hover:border-gray-400 transition-colors cursor-pointer"
+              className="bg-gray-50 border-2 border-gray-300 rounded-lg p-6 hover:border-gray-400 transition-colors cursor-pointer"
               onClick={() => handleMethodSelect('manual')}
             >
-              <h3 className="text-lg font-semibold mb-2">
+              <div className="flex items-center gap-2 text-gray-600 mb-4">
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span className="text-sm font-medium">
+                  Up to a week to approve your application
+                </span>
+              </div>
+
+              <h3 className="text-xl font-bold mb-2">
                 Manual Statement Upload
+                <br />
+                <br />
               </h3>
               <p className="text-sm text-gray-600 mb-4">
-                Please upload your last 3 months of bank statements to help us
+                Please upload your last 6 months of bank statements to help us
                 review your business.
               </p>
-              <button className="w-full bg-gray-800 text-white py-3 px-4 rounded-lg font-medium hover:bg-gray-700 transition-colors">
+              <button className="w-full bg-gray-800 text-white py-3 px-4 rounded-lg font-semibold hover:bg-gray-700 transition-colors">
                 Upload Bank Statements
               </button>
               <div className="mt-4 space-y-2">
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-gray-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1565,9 +1605,9 @@ function Step12Form({
                   </svg>
                   Standard credit evaluation with manual review
                 </div>
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-700">
                   <svg
-                    className="w-5 h-5 text-green-500 mr-2 mt-0.5"
+                    className="w-5 h-5 text-gray-500 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >
@@ -1579,9 +1619,9 @@ function Step12Form({
                   </svg>
                   Your documents are protected with bank-level security
                 </div>
-                <div className="flex items-start text-sm text-gray-600">
+                <div className="flex items-start text-sm text-gray-500">
                   <svg
-                    className="w-5 h-5 text-gray-400 mr-2 mt-0.5"
+                    className="w-5 h-5 text-gray-400 mr-2 mt-0.5 flex-shrink-0"
                     fill="currentColor"
                     viewBox="0 0 20 20"
                   >

--- a/src/app/step/[id]/page.tsx
+++ b/src/app/step/[id]/page.tsx
@@ -1584,7 +1584,7 @@ function Step12Form({
                 <br />
               </h3>
               <p className="text-sm text-gray-600 mb-4">
-                Please upload your last 6 months of bank statements to help us
+                Please upload 3 bank statements of the last 6 months to help us
                 review your business.
               </p>
               <button className="w-full bg-gray-800 text-white py-3 px-4 rounded-lg font-semibold hover:bg-gray-700 transition-colors">
@@ -1698,7 +1698,7 @@ function Step12Form({
                   Upload Bank Statements Manually
                 </h3>
                 <p className="text-sm text-gray-600 mt-1">
-                  Please upload six bank statements that are no older than six
+                  Please upload three bank statements that are no older than six
                   months to help us understand your business.
                 </p>
               </div>

--- a/src/app/step/[id]/page.tsx
+++ b/src/app/step/[id]/page.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, useParams } from 'next/navigation';
-import { FormData } from '@/types';
+import { type FormData } from '@/types';
 
 // Declare Facebook Pixel types
 declare global {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -205,7 +205,7 @@ export async function submitApplication(
     const responseData = {
       success: true,
       message: 'Application submitted successfully',
-      applicationId: savedApplication.id!,
+      applicationId: savedApplication.id,
       data: {
         id: savedApplication.id!,
         businessName: savedApplication.business_name,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -85,6 +85,9 @@ export interface ApplicationData {
   agreesToTerms: string;
   authorizesCreditCheck: string;
 
+  // Bank upload tracking
+  applicationUploadId?: string;
+
   // Application Metadata
   ipAddress?: string;
 
@@ -237,18 +240,12 @@ export async function submitApplication(
     }
 
     // Handle bank statements if manual upload was used
-    if (
-      data.bankConnectionMethod === 'manual' &&
-      data.bankStatements &&
-      data.bankStatements.length > 0
-    ) {
-      // Update the bank_statements records with the application_id
-      const statementIds = data.bankStatements.map((stmt: any) => stmt.id);
-
+    if (data.bankConnectionMethod === 'manual' && data.applicationUploadId) {
+      // Update all bank_statements records with this applicationUploadId to link them to the application
       const { error: statementsError } = await supabase
         .from('bank_statements')
         .update({ application_id: savedApplication.id! })
-        .in('id', statementIds);
+        .eq('application_upload_id', data.applicationUploadId);
 
       if (statementsError) {
         console.error('Error linking bank statements:', statementsError);

--- a/src/types/form-data.ts
+++ b/src/types/form-data.ts
@@ -1,4 +1,12 @@
 export interface FormData {
   [key: string]: any;
   existingLoans?: Array<{ lenderName: string; loanAmount: string }>;
+  bankConnectionMethod?: 'flinks' | 'manual' | '';
+  bankStatements?: Array<{
+    id: string;
+    fileName: string;
+    fileUrl: string;
+    fileSize: number;
+    mimeType: string;
+  }>;
 }

--- a/supabase/migrations/20250701000000_create_bank_statements_table.sql
+++ b/supabase/migrations/20250701000000_create_bank_statements_table.sql
@@ -5,9 +5,8 @@ CREATE TABLE IF NOT EXISTS "public"."bank_statements" (
     "application_upload_id" uuid NOT NULL,
     "file_url" text NOT NULL,
     "file_name" character varying(255) NOT NULL,
-    "file_size" bigint,
-    "mime_type" character varying(100),
-    "uploaded_at" timestamp with time zone DEFAULT "now"()
+    "file_size" bigint NOT NULL,
+    "mime_type" character varying(100) NOT NULL
 );
 
 ALTER TABLE "public"."bank_statements" OWNER TO "postgres";

--- a/supabase/migrations/20250701000000_create_bank_statements_table.sql
+++ b/supabase/migrations/20250701000000_create_bank_statements_table.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS "public"."bank_statements" (
+    "id" bigint NOT NULL,
+    "created_at" timestamp with time zone DEFAULT "now"(),
+    "application_id" bigint,
+    "file_url" text NOT NULL,
+    "file_name" character varying(255) NOT NULL,
+    "file_size" bigint,
+    "mime_type" character varying(100),
+    "uploaded_at" timestamp with time zone DEFAULT "now"()
+);
+
+ALTER TABLE "public"."bank_statements" OWNER TO "postgres";
+
+CREATE SEQUENCE IF NOT EXISTS "public"."bank_statements_id_seq"
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+ALTER SEQUENCE "public"."bank_statements_id_seq" OWNER TO "postgres";
+
+ALTER SEQUENCE "public"."bank_statements_id_seq" OWNED BY "public"."bank_statements"."id";
+
+ALTER TABLE ONLY "public"."bank_statements" ALTER COLUMN "id" SET DEFAULT "nextval"('public.bank_statements_id_seq'::regclass);
+
+ALTER TABLE ONLY "public"."bank_statements"
+    ADD CONSTRAINT "bank_statements_pkey" PRIMARY KEY ("id");
+
+ALTER TABLE ONLY "public"."bank_statements"
+    ADD CONSTRAINT "bank_statements_application_id_fkey" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE CASCADE;
+
+CREATE INDEX "idx_bank_statements_application_id" ON "public"."bank_statements" USING "btree" ("application_id");
+
+ALTER TABLE "public"."bank_statements" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow anon access to bank_statements" ON "public"."bank_statements" TO "anon" USING (true) WITH CHECK (true);
+CREATE POLICY "Service role can manage bank_statements" ON "public"."bank_statements" TO "service_role" USING (true) WITH CHECK (true);

--- a/supabase/migrations/20250701000000_create_bank_statements_table.sql
+++ b/supabase/migrations/20250701000000_create_bank_statements_table.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS "public"."bank_statements" (
     "id" bigint NOT NULL,
     "created_at" timestamp with time zone DEFAULT "now"(),
     "application_id" bigint,
+    "application_upload_id" uuid NOT NULL,
     "file_url" text NOT NULL,
     "file_name" character varying(255) NOT NULL,
     "file_size" bigint,
@@ -31,6 +32,8 @@ ALTER TABLE ONLY "public"."bank_statements"
     ADD CONSTRAINT "bank_statements_application_id_fkey" FOREIGN KEY ("application_id") REFERENCES "public"."applications"("id") ON DELETE CASCADE;
 
 CREATE INDEX "idx_bank_statements_application_id" ON "public"."bank_statements" USING "btree" ("application_id");
+
+CREATE INDEX "idx_bank_statements_application_upload_id" ON "public"."bank_statements" USING "btree" ("application_upload_id");
 
 ALTER TABLE "public"."bank_statements" ENABLE ROW LEVEL SECURITY;
 

--- a/supabase/migrations/20250701000001_create_bank_statements_bucket.sql
+++ b/supabase/migrations/20250701000001_create_bank_statements_bucket.sql
@@ -1,0 +1,34 @@
+-- Create storage bucket for bank statements
+INSERT INTO storage.buckets (id, name, public, avif_autodetection, file_size_limit, allowed_mime_types)
+VALUES (
+  'bank-statements',
+  'bank-statements',
+  false, -- Private bucket - files cannot be accessed without authentication
+  false,
+  10485760, -- 10MB limit
+  ARRAY['application/pdf', 'image/png', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Set up RLS policies for the bucket
+CREATE POLICY "Anyone can upload bank statements" ON storage.objects
+  FOR INSERT TO anon, authenticated
+  WITH CHECK (bucket_id = 'bank-statements');
+
+-- Only authenticated users can view their own bank statements
+-- Note: This policy would need additional logic to check ownership
+-- For now, we'll rely on the service role to control access
+CREATE POLICY "Service role can view bank statements" ON storage.objects
+  FOR SELECT TO service_role
+  USING (bucket_id = 'bank-statements');
+
+-- Service role can update bank statements
+CREATE POLICY "Service role can update bank statements" ON storage.objects
+  FOR UPDATE TO service_role
+  USING (bucket_id = 'bank-statements')
+  WITH CHECK (bucket_id = 'bank-statements');
+
+-- Service role can delete bank statements
+CREATE POLICY "Service role can delete bank statements" ON storage.objects
+  FOR DELETE TO service_role
+  USING (bucket_id = 'bank-statements');

--- a/supabase/migrations/20250701000001_create_bank_statements_bucket.sql
+++ b/supabase/migrations/20250701000001_create_bank_statements_bucket.sql
@@ -6,7 +6,7 @@ VALUES (
   false, -- Private bucket - files cannot be accessed without authentication
   false,
   10485760, -- 10MB limit
-  ARRAY['application/pdf', 'image/png', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']
+  ARRAY['application/pdf']
 )
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
## Problem

One problem regarding RFI is that some customers can't or are not willing to use the Flinks connection. For them, we need to enable a path form them to manually upload the bank statements 

## Changes

* There's a new bank_statements table. Since application id is not set immediately, we use a UUID to link the bank statements together, and we use that as a folder for the uploads
* UI changes to make this possible. See evidence for that
* Added api endpoint to upload files
* Added a migration for creating the bucket (that's the most declarative way to handle bucket creation in Supabase). Bucket is private so you cannot download publicly for now. We need to figure out best way to expose this to our internal users.

## Evidence
https://www.loom.com/share/ccfe52d6f8d942b885e8cda4587bd75d?sid=d9e4db87-cc21-4a3f-8ee4-90b27def3670