### PR TITLE
Stop recording logrocket replays for non-production environments

### DIFF
--- a/src/hooks/use-logrocket.ts
+++ b/src/hooks/use-logrocket.ts
@@ -8,6 +8,10 @@ import { getLogRocketOptions } from '@/utils/session-recordings';
 import { extractApplicationData } from '@/utils/application';
 import { getApplicationTraits } from '@/utils/analytics/traits';
 
+const shouldInitializeLogRocket =
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'production' &&
+  isDefined(process.env.NEXT_PUBLIC_LOGROCKET_APP_ID);
+
 export const useLogRocket = () => {
   const pathname = usePathname();
   const logRocketInitialized = useRef(false);
@@ -20,11 +24,13 @@ export const useLogRocket = () => {
       const logRocketOptions = getLogRocketOptions({
         shouldSendData: () => shouldSendData.current, // Required to keep reference to the original value
       });
-      LogRocket.init(
-        process.env.NEXT_PUBLIC_LOGROCKET_APP_ID ?? '',
-        logRocketOptions
-      );
-      logRocketInitialized.current = true;
+      if (shouldInitializeLogRocket) {
+        LogRocket.init(
+          process.env.NEXT_PUBLIC_LOGROCKET_APP_ID ?? '',
+          logRocketOptions
+        );
+        logRocketInitialized.current = true;
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Problem
- We needed a way to stop recording sessions that are not production (to avoid consuming unnecessary quota)
## Changes
-[fix: 🩹 avoid initializing logrocket if environment is not production or app id is missing](https://github.com/try-keep/referral-capital-application/commit/dda4b6278100263bff2ed3efef14f7f8e20da88d) 


## Evidence

