### PR TITLE
[GRO-75] Add business address page with auto-complete

### DIFF
--- a/src/components/forms/application/v2/business-address.tsx
+++ b/src/components/forms/application/v2/business-address.tsx
@@ -1,18 +1,94 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
-import { Building2, Search, ChevronUp } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { Building2, Phone, Globe } from 'lucide-react';
 import { FormData } from '@/types';
 import ApplicationStepWrapper from './ApplicationStepWrapper';
 import { useApplicationStep } from '@/contexts/';
+import {
+  AddressAutocompleteInput,
+  AddressSuggestion,
+} from '@/components/AddressAutocompleteInput';
+
+const CURRENT_STEP_ID = 'business-address';
 
 const BusinessAddress = () => {
-  const { formData, saveFormData, isStepCompleted, moveForward, isNavigating } =
-    useApplicationStep('business-address');
+  const {
+    formData,
+    saveFormData,
+    isStepCompleted,
+    moveForward,
+    isNavigating,
+    moveBackward,
+  } = useApplicationStep(CURRENT_STEP_ID);
 
-  const [localFormData, setLocalFormData] = useState<FormData>({});
+  const [localFormData, setLocalFormData] = useState<FormData>({
+    businessAddressLine1: '',
+    businessAddressLine2: '',
+    businessCity: '',
+    businessProvince: '',
+    businessPostalCode: '',
+    businessCountry: '', // Added for address suggestions
+    businessPhone: '',
+    websiteUrl: '',
+    businessAddress: '', // For backwards compatibility
+  });
 
-  const canGoNext = isStepCompleted('business-address') && !isNavigating;
+  const combineBusinessAddress = (data: FormData) => {
+    const {
+      businessAddressLine1,
+      businessAddressLine2,
+      businessCity,
+      businessProvince,
+      businessPostalCode,
+    } = data;
+    return [
+      businessAddressLine1,
+      businessAddressLine2,
+      businessCity,
+      businessProvince,
+      businessPostalCode,
+    ]
+      .filter(Boolean)
+      .join(', ');
+  };
+
+  useEffect(() => {
+    const initialData = {
+      businessAddressLine1: formData.businessAddressLine1 || '',
+      businessAddressLine2: formData.businessAddressLine2 || '',
+      businessCity: formData.businessCity || '',
+      businessProvince: formData.businessProvince || '',
+      businessPostalCode: formData.businessPostalCode || '',
+      businessPhone: formData.businessPhone || '',
+      websiteUrl: formData.websiteUrl || '',
+    };
+    setLocalFormData(initialData);
+  }, [formData]);
+
+  const handleInputChange = (field: string, value: string) => {
+    const updatedData = { ...localFormData, [field]: value };
+    updatedData.businessAddress = combineBusinessAddress(updatedData);
+    setLocalFormData(updatedData);
+    saveFormData(updatedData);
+  };
+
+  const handleSuggestionSelected = (address: AddressSuggestion) => {
+    const updatedData = {
+      ...localFormData,
+      businessAddressLine1: address.address_line1 || '',
+      businessAddressLine2: address.address_line2 || '',
+      businessCity: address.city || '',
+      businessProvince: address.state || '',
+      businessPostalCode: address.postcode || '',
+      businessCountry: address.country || '',
+      businessAddress: '',
+    };
+    updatedData.businessAddress = combineBusinessAddress(updatedData);
+    setLocalFormData(updatedData);
+    saveFormData(updatedData);
+  };
+
   const handleNext = async () => {
     try {
       await moveForward(localFormData);
@@ -21,15 +97,168 @@ const BusinessAddress = () => {
     }
   };
 
+  const canGoNext = isStepCompleted(CURRENT_STEP_ID) && !isNavigating;
+
   return (
     <ApplicationStepWrapper
       title="Business Address & Contact Information"
       onNext={handleNext}
-      canGoNext={canGoNext}
+      canGoNext={!!canGoNext}
       isSubmitting={isNavigating}
-      stepId="business-address"
+      stepId={CURRENT_STEP_ID}
+      onBack={() => {
+        moveBackward();
+      }}
     >
-      <p>WIP</p>
+      <div className="w-full mx-auto space-y-8">
+        {/* Header */}
+        <div className="mb-6 flex items-center space-x-2">
+          <Building2 className="text-blue-500" size={20} />
+          <h3 className="text-xl font-bold text-gray-800">Business Address</h3>
+        </div>
+
+        <div className="space-y-4">
+          {/* Street Address */}
+          <div className="relative">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Street Address *
+            </label>
+            <AddressAutocompleteInput
+              address={localFormData.businessAddressLine1}
+              onSuggestionSelected={(address) => {
+                handleSuggestionSelected(address);
+              }}
+              onAddressChange={(addressLine1) => {
+                handleInputChange('businessAddressLine1', addressLine1);
+              }}
+              placeholder="e.g., 470 Yonge St"
+              required
+              className="w-full p-3 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+            />
+          </div>
+          {/* Apartment/Suite */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Apartment, suite, etc. (Optional)
+            </label>
+            <input
+              type="text"
+              value={localFormData.businessAddressLine2}
+              onChange={(e) =>
+                handleInputChange('businessAddressLine2', e.target.value)
+              }
+              placeholder="e.g., Suite 100"
+              className="w-full p-3 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+            />
+          </div>
+          {/* City, Province, Postal Code Row */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {/* City */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                City *
+              </label>
+              <input
+                type="text"
+                value={localFormData.businessCity}
+                onChange={(e) =>
+                  handleInputChange('businessCity', e.target.value)
+                }
+                placeholder="e.g., Toronto"
+                required
+                className="w-full p-3 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+              />
+            </div>
+
+            {/* Province/State */}
+            <div className="relative">
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Province *
+              </label>
+              <input
+                type="text"
+                value={localFormData.businessProvince}
+                onChange={(e) =>
+                  handleInputChange('businessProvince', e.target.value)
+                }
+                placeholder="e.g., Ontario"
+                required
+                className="w-full p-3 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+              />
+            </div>
+
+            {/* Postal Code */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Postal Code *
+              </label>
+              <input
+                type="text"
+                value={localFormData.businessPostalCode}
+                onChange={(e) =>
+                  handleInputChange('businessPostalCode', e.target.value)
+                }
+                placeholder="e.g., M5A 1A1"
+                required
+                className="w-full p-3 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-200 outline-none transition-all duration-200"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Contact Information */}
+        <div className="mb-6 flex items-center space-x-2">
+          <Phone className="text-blue-500" size={20} />
+          <h3 className="text-xl font-bold text-gray-800">
+            Contact Information
+          </h3>
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Business Phone */}
+          <div className="relative">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Business Phone Number *
+            </label>
+            <div className="relative">
+              <Phone
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                size={20}
+              />
+              <input
+                type="tel"
+                value={localFormData.businessPhone}
+                onChange={(e) =>
+                  handleInputChange('businessPhone', e.target.value)
+                }
+                placeholder="e.g., (123) 456-7890"
+                required
+                className="w-full p-3 pl-10 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+              />
+            </div>
+          </div>
+          {/* Website URL */}
+          <div className="relative">
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Business Website (Optional)
+            </label>
+            <div className="relative">
+              <Globe
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                size={20}
+              />
+              <input
+                type="url"
+                value={localFormData.websiteUrl}
+                onChange={(e) =>
+                  handleInputChange('websiteUrl', e.target.value)
+                }
+                placeholder="e.g., https://www.example.com"
+                className="w-full p-3 pl-10 text-lg border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition-all duration-200"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
     </ApplicationStepWrapper>
   );
 };

--- a/src/constants/application/index.ts
+++ b/src/constants/application/index.ts
@@ -66,7 +66,13 @@ export const APPLICATION_STEPS: ApplicationStep[] = [
     id: 'business-address',
     label: 'Business Address & Contact Information',
     description: 'Business Address & Contact Information',
-    requiredFields: [],
+    requiredFields: [
+      'businessAddressLine1',
+      'businessCity',
+      'businessProvince',
+      'businessPostalCode',
+      'businessPhone',
+    ],
   },
   {
     id: 'business-entity-type',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -79,6 +79,12 @@ export interface ApplicationData {
   // Step 13: Additional Details
   businessAddress: string;
   businessPhone: string;
+  businessCountry?: string;
+  businessAddressLine1?: string;
+  businessAddressLine2?: string;
+  businessCity?: string;
+  businessProvince?: string;
+  businessPostalCode?: string;
   websiteUrl?: string;
   additionalInfo?: string;
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -129,6 +129,13 @@ export interface ApplicationData {
   // Step 13: Additional Details
   business_address: string;
   business_phone: string;
+  business_address_line1?: string;
+  business_address_line2?: string;
+  business_address_city?: string;
+  business_address_province?: string;
+  business_address_postal_code?: string;
+  business_address_country?: string;
+
   website_url?: string;
   additional_info?: string;
 

--- a/supabase/migrations/20250710231022_add_business_address_fields.sql
+++ b/supabase/migrations/20250710231022_add_business_address_fields.sql
@@ -1,0 +1,9 @@
+ALTER TABLE applications
+  ADD COLUMN business_address_line1 VARCHAR(255) NULL,
+  ADD COLUMN business_address_line2 VARCHAR(255) NULL,
+  ADD COLUMN business_address_city VARCHAR(255) NULL,
+  ADD COLUMN business_address_province VARCHAR(255) NULL,
+  ADD COLUMN business_address_postal_code VARCHAR(255) NULL,
+  -- I know we said Canada only but just in case.
+  ADD COLUMN business_address_country VARCHAR(255) NULL;
+


### PR DESCRIPTION
## Problem

Business address and contact information was deemed complex and different enough for the new form that it was decided
was going to use a different task during planning. It is a bit different form the designs since we are not prompting
for a country and we are reusing the address search that was created for the personal address step.

## Changes

* New fields for business address were added to the database in the applications table.
  These fields are populated using the api doing some passing around of properties.
* Business address component was implemented and required fields were defined. Of note is that for
  backwards-compatibility reasons, we are storing the version "in-full" of the address to be sent to the
  businessAddress field.

## How does it look?
<img width="1836" height="1612" alt="image" src="https://github.com/user-attachments/assets/2392b05e-33ed-47a0-bd90-8bf9fd2cd66a" />
